### PR TITLE
Add igly.ai to image generator tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ This is an atlas of AI tools that are available on the web. This directory conta
 - [getimg.ai](https://getimg.ai/)  
    Easily generate images from text, edit photos with words, expand pictures beyond their borders, train custom AI models and much more.
 
+- [igly.ai](https://igly.ai)
+   AI image editing for background removal, inpainting, upscaling, and generative fill.
+
 - [Ilus AI](https://ilus.ai/)  
    Get beautiful, stylistically consistent illustrations in minutes.
 
@@ -1388,4 +1391,3 @@ The list is not complete also with the speed of the AI industry, there is a lot 
 ---
 
 Created by [Mosn](https://forge.mosn.me?ref=github-ai)
-


### PR DESCRIPTION
Adds igly.ai under the Image Generator section. igly.ai is an AI image editing platform covering background removal, inpainting, upscaling, and generative fill.

Demo/reference: https://www.youtube.com/watch?v=HB2E1WZ12is

Checked before submitting:
- igly.ai was not already listed
- Added one entry matching the local README style
- Markdown diff passes `git diff --check`